### PR TITLE
added c_uint16 to imports from ctypes

### DIFF
--- a/src/quick2wire/i2c_ctypes.py
+++ b/src/quick2wire/i2c_ctypes.py
@@ -3,7 +3,7 @@
 # Converted from i2c.h and i2c-dev.h
 # I2C only, no SMB definitions
 
-from ctypes import c_int, c_ushort, c_short, c_ubyte, c_char, POINTER, Structure
+from ctypes import c_int, c_uint16, c_ushort, c_short, c_ubyte, c_char, POINTER, Structure
 
 # /usr/include/linux/i2c-dev.h: 38
 class i2c_msg(Structure):


### PR DESCRIPTION
Got the following error in Raspbian with python3.2:

File "/[...]/quick2wire-python-api/src/quick2wire/i2c_ctypes.py", line 13, in i2c_msg
    ('addr', c_uint16),
NameError: name 'c_uint16' is not defined
