### PR TITLE
Pin-Header changes in Rev2

### DIFF
--- a/src/quick2wire/gpio.py
+++ b/src/quick2wire/gpio.py
@@ -38,6 +38,8 @@ RaspberryPi_HeaderToSOC = {
     26: 8
 }
 if revision()>1:
+    RaspberryPi_HeaderToSOC[3] = 2
+    RaspberryPi_HeaderToSOC[5] = 3
     RaspberryPi_HeaderToSOC[13] = 27
 
 def header_to_soc(header_pin_number):


### PR DESCRIPTION
According to http://elinux.org/RPi_Low-level_peripherals#General_Purpose_Input.2FOutput_.28GPIO.29 there has been more than one change in Rev2 concerning the GPIO-Pins.

Currently /src/quick2wire/gpio.py has only this:

```
if revision()>1:
    RaspberryPi_HeaderToSOC[13] = 27
```

But according to the link provided above, this should probably read:

```
if revision()>1:
    RaspberryPi_HeaderToSOC[3] = 2
    RaspberryPi_HeaderToSOC[5] = 3
    RaspberryPi_HeaderToSOC[13] = 27
```
