### PR TITLE
timerfd follows ctypes naming convention used in i2c_ctypes.py	

### DIFF
--- a/quick2wire/test_timerfd.py
+++ b/quick2wire/test_timerfd.py
@@ -5,16 +5,16 @@ from quick2wire.timerfd import Timer, timespec, itimerspec
 
 def test_timespec_can_be_created_from_seconds():
     t = timespec.from_seconds(4.125)
-    assert t.tv_sec == 4
-    assert t.tv_nsec == 125000000
+    assert t.sec == 4
+    assert t.nsec == 125000000
 
 
 def test_itimerspec_can_be_created_from_seconds():
     t = itimerspec.from_seconds(offset=4.125, interval=1.25)
-    assert t.it_value.tv_sec == 4
-    assert t.it_value.tv_nsec == 125000000
-    assert t.it_interval.tv_sec == 1
-    assert t.it_interval.tv_nsec == 250000000
+    assert t.value.sec == 4
+    assert t.value.nsec == 125000000
+    assert t.interval.sec == 1
+    assert t.interval.nsec == 250000000
 
 
 def test_timer_waits_for_time_to_pass():

--- a/quick2wire/timerfd.py
+++ b/quick2wire/timerfd.py
@@ -15,8 +15,8 @@ time_t = c_long
 clockid_t = c_ulong
 
 class timespec(Structure):
-    _fields_ = [("tv_sec", time_t),
-                ("tv_nsec", c_long)]
+    _fields_ = [("sec", time_t),
+                ("nsec", c_long)]
     
     __slots__ = [name for name,type in _fields_]
     
@@ -28,29 +28,29 @@ class timespec(Structure):
     
     @property
     def seconds(self):
-        if self.tv_nsec == 0:
-            return self.tv_sec
+        if self.nsec == 0:
+            return self.sec
         else:
-            return self.tv_sec + self.tv_nsec / 1000000000.0
+            return self.sec + self.nsec / 1000000000.0
         
     @seconds.setter
     def seconds(self, secs):
         fractional, whole = math.modf(secs)
-        self.tv_sec = int(whole)
-        self.tv_nsec = int(fractional * 1000000000)
+        self.sec = int(whole)
+        self.nsec = int(fractional * 1000000000)
 
 
 class itimerspec(Structure):
-    _fields_ = [("it_interval", timespec), 
-                ("it_value", timespec)]
+    _fields_ = [("interval", timespec), 
+                ("value", timespec)]
     
     __slots__ = [name for name,type in _fields_]
     
     @classmethod
     def from_seconds(cls, offset, interval):
         spec = cls()
-        spec.it_value.seconds = offset
-        spec.it_interval.seconds = interval
+        spec.value.seconds = offset
+        spec.interval.seconds = interval
         return spec
 
 


### PR DESCRIPTION
Removes tv_ or it_ prefixes from field names. they're really only useful to avoid name-clash when aliasing field names with CPP macros.
