### PR TITLE
python version check when importing i2c and spi modules

### DIFF
--- a/quick2wire/i2c.py
+++ b/quick2wire/i2c.py
@@ -1,10 +1,14 @@
 
+import sys
 from contextlib import closing
 import posix
 from fcntl import ioctl
 from quick2wire.i2c_ctypes import *
 from ctypes import create_string_buffer, sizeof, c_int, byref, pointer, addressof, string_at
 from quick2wire.board_revision import revision
+
+assert sys.version_info.major >= 3, __name__ + " is only supported on Python 3"
+
 
 default_bus = 1 if revision() > 1 else 0
 

--- a/quick2wire/spi.py
+++ b/quick2wire/spi.py
@@ -1,9 +1,12 @@
+import sys
 from ctypes import addressof, create_string_buffer, sizeof, string_at
 import struct
 import posix
 from fcntl import ioctl
 from quick2wire.spi_ctypes import *
 from quick2wire.spi_ctypes import spi_ioc_transfer, SPI_IOC_MESSAGE
+
+assert sys.version_info.major >= 3, __name__ + " is only supported on Python 3"
 
 
 class SPIDevice:


### PR DESCRIPTION
Now clearly reports that i2c is only supported on Python 3 and aborts with an AssertionError.
