### PR TITLE
PCF8591 API fixes

### DIFF
--- a/quick2wire/parts/pcf8591.py
+++ b/quick2wire/parts/pcf8591.py
@@ -192,13 +192,13 @@ class PCF8591(object):
     
     def read_raw(self, channel):
         if channel != self._last_channel_read:
-            self.master.transaction(
-                writing_bytes(self.address, self._control_flags|channel),
-                reading(self.address, 1))
+            self.master.transaction(writing_bytes(self.address, self._control_flags|channel),
+                                    reading(self.address, 2))
             self._last_channel_read = channel
         
-        results = self.master.transaction(reading(self.address, 1))
-        return results[0][0]
+        results = self.master.transaction(
+            reading(self.address, 2))
+        return results[0][-1]
 
 
 class _OutputChannel(object):

--- a/quick2wire/parts/test_pcf8591.py
+++ b/quick2wire/parts/test_pcf8591.py
@@ -61,12 +61,7 @@ def correct_message_for(adc):
     def check(m):
         assert m.addr == adc.address
         assert m.flags in (0, I2C_M_RD)
-        
-        if is_write(m):
-            assert m.len == 1 or m.len == 2
-        
-        if is_read(m):
-            assert m.len == 1, "only ever read single bytes"
+        assert m.len == 1 or m.len == 2
     
     return check
 
@@ -118,8 +113,8 @@ def test_can_read_a_single_ended_pin():
     
     pin = adc.single_ended_input(2)
     
-    i2c.add_response(bytes([0x80]))
-    i2c.add_response(bytes([0x40]))
+    i2c.add_response(bytes([0x80, 0x60]))
+    i2c.add_response(bytes([0x40, 0x40]))
     
     sample = pin.value
     
@@ -131,11 +126,11 @@ def test_can_read_a_single_ended_pin():
     assert m1a.buf[0][0] == 0b00000010
     
     assert is_read(m1b)
-    assert m1b.len == 1
+    assert m1b.len == 2
     
     m2, = i2c.request(1)
     assert is_read(m2)
-    assert m2.len == 1
+    assert m2.len == 2
     
     assert_is_approx(0.25, sample)
 
@@ -145,8 +140,8 @@ def test_can_read_raw_value_of_a_single_ended_pin():
     
     pin = adc.single_ended_input(2)
     
-    i2c.add_response(bytes([0x80]))
-    i2c.add_response(bytes([0x40]))
+    i2c.add_response(bytes([0x80, 0x60]))
+    i2c.add_response(bytes([0x40, 0x40]))
     
     sample = pin.raw_value
     
@@ -158,11 +153,11 @@ def test_can_read_raw_value_of_a_single_ended_pin():
     assert m1a.buf[0][0] == 0b00000010
     
     assert is_read(m1b)
-    assert m1b.len == 1
+    assert m1b.len == 2
     
     m2, = i2c.request(1)
     assert is_read(m2)
-    assert m2.len == 1
+    assert m2.len == 2
     
     assert sample == 0x40
 
@@ -173,10 +168,10 @@ def test_can_read_a_differential_pin():
     pin = adc.differential_input(1)
     
 
-    i2c.add_response(bytes([0x80]))
+    i2c.add_response(bytes([0x80, 0x60]))
     
     # -64 in 8-bit 2's complement representation
-    i2c.add_response(bytes([0xC0]))
+    i2c.add_response(bytes([0xC0, 0xC0]))
     
     sample = pin.raw_value
     
@@ -188,11 +183,11 @@ def test_can_read_a_differential_pin():
     assert m1a.buf[0][0] == 0b00010001
     
     assert is_read(m1b)
-    assert m1b.len == 1
+    assert m1b.len == 2
     
     m2, = i2c.request(1)
     assert is_read(m2)
-    assert m2.len == 1
+    assert m2.len == 2
     
     assert sample == -64
 
@@ -202,11 +197,10 @@ def test_can_read_raw_value_of_a_differential_pin():
     
     pin = adc.differential_input(1)
     
-
-    i2c.add_response(bytes([0x80]))
+    i2c.add_response(bytes([0x80, 0x60]))
     
     # -64 in 8-bit 2's complement representation
-    i2c.add_response(bytes([0xC0]))
+    i2c.add_response(bytes([0xC0, 0xC0]))
     
     sample = pin.value
     
@@ -218,11 +212,11 @@ def test_can_read_raw_value_of_a_differential_pin():
     assert m1a.buf[0][0] == 0b00010001
     
     assert is_read(m1b)
-    assert m1b.len == 1
+    assert m1b.len == 2
     
     m2, = i2c.request(1)
     assert is_read(m2)
-    assert m2.len == 1
+    assert m2.len == 2
     
     assert_is_approx(-0.25, sample)
 
@@ -302,7 +296,7 @@ def test_switches_channel_and_reads_twice_when_reading_from_different_pin():
     assert ma.len == 1
     assert ma.buf[0][0] == 0b00000001
     assert is_read(mb)
-    assert mb.len == 1
+    assert mb.len == 2
     
 
 def test_opening_and_closing_the_output_pin_turns_the_digital_to_analogue_converter_on_and_off():

--- a/quick2wire/parts/test_pcf8591_loopback.py
+++ b/quick2wire/parts/test_pcf8591_loopback.py
@@ -2,9 +2,9 @@
 
 Topology:
 
- - connect AOUT to AIN3
- - connect AIN2 to 3V3
  - connect AIN1 to ground
+ - connect AIN2 to 3V3
+ - connect AIN3 to AOUT
  - connect VREF to 3v3
  - connect AGND to ground
  - AIN0 is unused
@@ -26,20 +26,32 @@ def teardown_function(f):
     i2c.close()
 
 
-def assert_is_approx(expected, actual, input_v, delta=0.02):
+def assert_is_approx(expected, actual, delta=0.02):
     assert abs(actual - expected) <= delta
 
 
 @pytest.mark.loopback
 @pytest.mark.pcf8591
 def test_pcf8591_loopback_single_ended():
-    adc = PCF8591(i2c, FOUR_SINGLE_ENDED, samples=5)
+    adc = PCF8591(i2c, FOUR_SINGLE_ENDED)
     input = adc.single_ended_input(3)
     
     with adc.output as output:
         for v in (i/255.0 for i in range(256)):
             output.value = v
-            assert_is_approx(v, input.value, v)
+            assert_is_approx(v, input.value)
+
+
+@pytest.mark.loopback
+@pytest.mark.pcf8591
+def test_pcf8591_loopback_switching_channels():
+    adc = PCF8591(i2c, FOUR_SINGLE_ENDED)
+    p1 = adc.single_ended_input(1)
+    p2 = adc.single_ended_input(2)
+    
+    for i in range(8):
+        assert p1.value == 0.0
+        assert p2.value == 1.0
 
 
 @pytest.mark.loopback
@@ -51,7 +63,7 @@ def test_pcf8591_loopback_differential_vref_to_ain3():
     with adc.output as output:
         for v in (i/255.0 for i in range(256)):
             output.value = v
-            assert_is_approx(min(0.5, 1-v), cmp_vref.value, v)
+            assert_is_approx(min(0.5, 1-v), cmp_vref.value)
 
 
 @pytest.mark.loopback
@@ -63,4 +75,4 @@ def test_pcf8591_loopback_differential_gnd_to_ain3():
     with adc.output as output:
         for v in (i/255.0 for i in range(256)):
             output.value = v
-            assert_is_approx(max(-0.5, -v), cmp_gnd.value, v)
+            assert_is_approx(max(-0.5, -v), cmp_gnd.value)


### PR DESCRIPTION
Exposed access to raw chip data and documented those low-level functions
Fixed switching between channels
Always read two bytes to ensure the caller gets an up-do-date ADC result.
