### PR TITLE
SAA1064 and Seven Segment display APIs

### DIFF
--- a/examples/saa1064-two-digits.py
+++ b/examples/saa1064-two-digits.py
@@ -1,0 +1,17 @@
+import quick2wire.i2c as i2c
+from quick2wire.parts.saa1064 import SAA1064, STATIC_MODE
+from time import sleep
+
+numbers=[126, 48, 109, 121, 51, 91, 95, 112, 127, 123]
+
+saa1064 = SAA1064(i2c.I2CMaster(), digits=2)
+saa1064.mode=STATIC_MODE
+saa1064.brightness=0b01100000
+saa1064.configure()
+
+for y in range(10):
+        saa1064.pin_bank(0).value=numbers[y]
+        for x in range(10):
+                saa1064.pin_bank(1).value=numbers[x]
+                saa1064.write()
+                sleep(0.1)

--- a/examples/saa1064-two-digits.py
+++ b/examples/saa1064-two-digits.py
@@ -2,16 +2,14 @@ import quick2wire.i2c as i2c
 from quick2wire.parts.saa1064 import SAA1064, STATIC_MODE
 from time import sleep
 
-numbers=[126, 48, 109, 121, 51, 91, 95, 112, 127, 123]
-
 saa1064 = SAA1064(i2c.I2CMaster(), digits=2)
 saa1064.mode=STATIC_MODE
 saa1064.brightness=0b01100000
 saa1064.configure()
 
 for y in range(10):
-        saa1064.pin_bank(0).value=numbers[y]
+        saa1064.digit(0).value(y)
         for x in range(10):
-                saa1064.pin_bank(1).value=numbers[x]
+                saa1064.digit(1).value(x)
                 saa1064.write()
                 sleep(0.1)

--- a/examples/saa1064-two-digits.py
+++ b/examples/saa1064-two-digits.py
@@ -3,9 +3,7 @@ from quick2wire.parts.saa1064 import SAA1064, STATIC_MODE
 from time import sleep
 
 saa1064 = SAA1064(i2c.I2CMaster(), digits=2)
-saa1064.mode=STATIC_MODE
 saa1064.brightness=0b01100000
-saa1064.configure()
 
 for y in range(10):
         saa1064.digit(0).value(y)

--- a/examples/seven_segment_display_with_two_digits.py
+++ b/examples/seven_segment_display_with_two_digits.py
@@ -5,12 +5,13 @@ from quick2wire.parts.saa1064 import SAA1064
 from quick2wire.parts.seven_segment_display import SevenSegmentDisplay
 from time import sleep
 
-saa1064 = SAA1064(i2c.I2CMaster(), digits=2)
-saa1064.configure()
-
-#TODO: Write a reset method.
-
+saa1064 = SAA1064(i2c.I2CMaster(), digits=4)
 sevenSegmentDisplay=SevenSegmentDisplay(saa1064)
+
 sevenSegmentDisplay.display('1.5')
 sleep(1)
-sevenSegmentDisplay.display('9R')
+sevenSegmentDisplay.display('100R')
+sleep(1)
+
+for i in range(9999):
+    sevenSegmentDisplay.display(i)

--- a/examples/seven_segment_display_with_two_digits.py
+++ b/examples/seven_segment_display_with_two_digits.py
@@ -1,0 +1,10 @@
+from quick2wire import i2c
+from quick2wire.parts.saa1064 import SAA1064
+from quick2wire.parts.seven_segment_display import SevenSegmentDisplay
+
+__author__ = 'stuartervine'
+
+saa1064 = SAA1064(i2c.I2CMaster(), digits=2)
+saa1064.configure()
+
+SevenSegmentDisplay(saa1064).display('1.5')

--- a/examples/seven_segment_display_with_two_digits.py
+++ b/examples/seven_segment_display_with_two_digits.py
@@ -1,10 +1,14 @@
+__author__ = 'stuartervine'
+
 from quick2wire import i2c
 from quick2wire.parts.saa1064 import SAA1064
 from quick2wire.parts.seven_segment_display import SevenSegmentDisplay
-
-__author__ = 'stuartervine'
+from time import sleep
 
 saa1064 = SAA1064(i2c.I2CMaster(), digits=2)
 saa1064.configure()
 
-SevenSegmentDisplay(saa1064).display('1.5')
+sevenSegmentDisplay=SevenSegmentDisplay(saa1064)
+sevenSegmentDisplay.display('1.5')
+sleep(1)
+sevenSegmentDisplay.display('9R')

--- a/examples/seven_segment_display_with_two_digits.py
+++ b/examples/seven_segment_display_with_two_digits.py
@@ -8,6 +8,8 @@ from time import sleep
 saa1064 = SAA1064(i2c.I2CMaster(), digits=2)
 saa1064.configure()
 
+#TODO: Write a reset method.
+
 sevenSegmentDisplay=SevenSegmentDisplay(saa1064)
 sevenSegmentDisplay.display('1.5')
 sleep(1)

--- a/quick2wire/gpio.py
+++ b/quick2wire/gpio.py
@@ -6,6 +6,7 @@ import os
 import subprocess
 from contextlib import contextmanager
 from quick2wire.board_revision import revision
+from quick2wire.pin import PinAPI, PinBankAPI
 from quick2wire.selector import EDGE
 
 
@@ -25,46 +26,6 @@ Both = "both"
     
 PullDown = "pulldown"
 PullUp = "pullup"
-
-
-
-class PinAPI(object):
-    def __init__(self, bank, index):
-        self._bank = bank
-        self._index = index
-    
-    @property
-    def index(self):
-        return self._index
-    
-    @property
-    def bank(self):
-        return self._bank
-    
-    def __enter__(self):
-        self.open()
-        return self
-    
-    def __exit__(self, exc_type, exc_value, traceback):
-        self.close()
-    
-    value = property(lambda p: p.get(), 
-                     lambda p,v: p.set(v), 
-                     doc="""The value of the pin: 1 if the pin is high, 0 if the pin is low.""")
-    
-
-class PinBankAPI(object):
-    def __getitem__(self, n):
-        if 0 < n < len(self):
-            raise ValueError("no pin index {n} out of range", n=n)
-        return self.pin(n)
-    
-    def write(self):
-        pass
-    
-    def read(self):
-        pass
-
 
 
 class Pin(PinAPI):
@@ -202,9 +163,6 @@ class Pin(PinAPI):
         return "{type}({index})".format(
             type=self.__class__.__name__, 
             index=self.index)
-
-
-
 
 
 class PinBank(PinBankAPI):

--- a/quick2wire/parts/fake_i2c.py
+++ b/quick2wire/parts/fake_i2c.py
@@ -28,13 +28,23 @@ class FakeI2CMaster:
     def request_count(self):
         return len(self._requests)
 
-
     def request(self, n):
         return self._requests[n]
+
+    def request_at(self, n):
+        return I2CRequestWrapper(self._requests[n])
 
     def message(self, message_index):
         request = self.request(0)
         return I2CMessageWrapper(request[message_index])
+
+class I2CRequestWrapper:
+    def __init__(self, i2c_request):
+            self._i2c_request = i2c_request
+
+    def message(self, index):
+        return I2CMessageWrapper(self._i2c_request[index])
+
 
 class I2CMessageWrapper:
     def __init__(self, i2_message):

--- a/quick2wire/parts/fake_i2c.py
+++ b/quick2wire/parts/fake_i2c.py
@@ -1,0 +1,46 @@
+__author__ = 'stuart'
+
+class FakeI2CMaster:
+    def __init__(self):
+        self._requests = []
+        self._responses = []
+        self._next_response = 0
+        self.message_precondition = lambda m: True
+
+    def all_messages_must(self, p):
+        self.message_precondition
+
+    def clear(self):
+        self.__init__()
+
+    def transaction(self, *messages):
+        for m in messages:
+            self.message_precondition(m)
+
+        self._requests.append(messages)
+        return []
+
+    def add_response(self, *messages):
+        self._responses.append(messages)
+
+
+    @property
+    def request_count(self):
+        return len(self._requests)
+
+
+    def request(self, n):
+        return self._requests[n]
+
+    def message(self, message_index):
+        request = self.request(0)
+        return I2CMessageWrapper(request[message_index])
+
+class I2CMessageWrapper:
+    def __init__(self, i2_message):
+        self._i2c_message = i2_message
+        self.len = i2_message.len
+
+    def byte(self, index):
+        return self._i2c_message.buf[index][0]
+

--- a/quick2wire/parts/saa1064.py
+++ b/quick2wire/parts/saa1064.py
@@ -32,7 +32,14 @@ digit_map = {
     '6':95,
     '7':112,
     '8':127,
-    '9':123
+    '9':123,
+    'A':119,
+    'B':31,
+    'C':78,
+    'D':61,
+    'E':79,
+    'F':71,
+    'R':5
 }
 
 class SAA1064(object):
@@ -51,8 +58,11 @@ class SAA1064(object):
         pass
 
     def configure(self):
+        self.write_control(self.mode|self._brightness|CONTINUOUS_DISPLAY)
+
+    def write_control(self, control_byte):
         self.master.transaction(
-            writing_bytes(displayController, 0b00000000, self.mode | self.brightness | CONTINUOUS_DISPLAY)
+            writing_bytes(displayController, 0b00000000, control_byte)
         )
 
     def write(self):
@@ -71,11 +81,13 @@ class SAA1064(object):
 
     @property
     def brightness(self):
-        return self._brightness
+        return self._brightness >> 5
 
     @brightness.setter
     def brightness(self, brightness):
-        self._brightness = brightness
+        if(brightness > 7):
+            raise ValueError('invalid brightness, valid between 0-7.')
+        self._brightness = brightness << 5
 
     def digit(self, index):
         return Digit(self._pin_bank[index])

--- a/quick2wire/parts/saa1064.py
+++ b/quick2wire/parts/saa1064.py
@@ -1,3 +1,63 @@
+"""
+API for the SAA1064 seven segment display driver chip.
+
+The SAA1064 can drive up to 4 seven segment displays simultaneously.
+There are 2 modes the chip can run in:
+
+STATIC mode - drives 2 seven segment displays.
+Where no multiplexing is required, and the outputs of the pins 3-11
+and 14-22 can be connected directly to the LED displays.
+[URL]
+
+DYNAMIC mode - drives 4 seven segment displays.
+The chip multiplexes the output of displays 1+3 and 2+4. The pairs
+of displays are connected to the same output pins as above. The circuit
+requires 2 transistors to be connected to the multiplex outputs to control
+which display to trigger.
+
+Applications talk to the chip via objects of the SAA1064 class. A
+SAA1064 object is created with an I2CMaster and a number of digits between 1-4.
+
+The display brightness can be supplied using the brightness property.
+This supports values between 0-7.
+
+The displays can then be controlled individually by setting valid values
+on digits and then calling write().
+
+For example:
+
+    with I2CMaster() as i2c:
+        saa1064 = SAA1064(i2c, digits=2)
+
+        saa1064.digit(0).value('1')
+        saa1064.digit(1).value('2')
+        saa1064.write()
+
+The current values supported for a digit are: 0-9, A-F, r
+
+Specifying a decimal point after the value will light the point in the display.
+
+For example:
+    with I2CMaster() as i2c:
+        saa1064 = SAA1064(i2c, digits=2)
+
+        saa1064.digit(0).value('1.')
+
+The displays are configured using the following value conversions for the display segments
+
+         --64--
+        |      |
+        2      32
+        |      |
+         -- 1--
+        |      |
+        4      16
+        |      |
+         -- 8--   DP-128
+
+"""
+
+
 __author__ = 'stuartervine'
 
 from functools import reduce
@@ -11,19 +71,7 @@ CONTINUOUS_DISPLAY = 0b00000110
 
 DECIMAL_POINT = 0b10000000
 
-"""
-    Value conversions for the display segments
 
-         --64--
-        |      |
-        2      32
-        |      |
-         -- 1--
-        |      |
-        4      16
-        |      |
-         -- 8--   DP-128
-    """
 digit_map = {
     '0':126,
     '1':48,
@@ -48,9 +96,9 @@ class SAA1064(object):
     def createPinBank(self, i):
         return _PinBank(i)
 
-    def __init__(self, master, digits=1):
+    def __init__(self, master, digits=1, brightness=7):
         self.master = master
-        self._brightness = 0b11100000
+        self.brightness = brightness
         if digits <= 0 or digits > 4:
             raise ValueError('SAA1064 only supports driving 1 to 4 digits')
         elif digits <= 2:
@@ -60,48 +108,55 @@ class SAA1064(object):
 
         self._pin_bank = tuple(self.createPinBank(i) for i in range(digits))
 
-    def display(self, digits):
-        pass
-
     def configure(self):
+        """Writes the configured control byte to the chip."""
         self.write_control(self.mode|self._brightness|CONTINUOUS_DISPLAY)
 
     def write_control(self, control_byte):
+        """Writes a raw control byte to the chip."""
         self.master.transaction(
             writing_bytes(displayController, 0b00000000, control_byte)
         )
 
     def write(self):
+        """Writes the segment outputs to the chip."""
         i2c_messages = [pin_bank.i2c_message for pin_bank in self._pin_bank]
         self.master.transaction(*i2c_messages)
 
     @property
     def mode(self):
+        """Returns the display mode the chip is currently configured in, 0: static, 1: dynamic"""
         return self._mode
 
     @mode.setter
     def mode(self, mode):
+        """Changes the display mode the chip is configured in."""
         if mode > 1 or mode < 0:
             raise ValueError('invalid mode ' + str(mode) + ' only STATIC_MODE and DYNAMIC_MODE are supported')
         self._mode = mode
 
     @property
     def brightness(self):
+        """Returns the current brightness level configured for the LED displays."""
         return self._brightness >> 5
 
     @brightness.setter
     def brightness(self, brightness):
+        """Sets the brightness of the LED displays, between 0-7."""
         if brightness > 7:
             raise ValueError('invalid brightness, valid between 0-7.')
         self._brightness = brightness << 5
 
     def digit(self, index):
+        """Returns a Digit object for the display at given 'index'."""
         return Digit(self._pin_bank[index])
 
     def pin_bank(self, index):
+        """Returns a PinBank object for the display at given 'index'."""
         return self._pin_bank[index]
 
     def __getitem__(self, n):
+        """Allows the SAA1064 to iterate through it's pin banks."""
         if 0 < n < len(self):
             raise ValueError('no pin bank index {n} out of range', n=n)
         return self._pin_bank[n]

--- a/quick2wire/parts/saa1064.py
+++ b/quick2wire/parts/saa1064.py
@@ -7,13 +7,14 @@ from quick2wire.i2c import writing_bytes
 
 displayController = 0x38
 STATIC_MODE = 0b00000000
-DYNAMIC_MODE = 0b01000000
+DYNAMIC_MODE = 0b00000001
+CONTINUOUS_DISPLAY = 0b00000110
 
 class SAA1064(object):
     def __init__(self, master):
         self.master = master
         self._mode = STATIC_MODE
-        self._brightness = 7
+        self._brightness = 0b11100000
         self._segment_output = tuple(_OutputPin(i) for i in range(8))
 
     def display(self, digits):
@@ -21,7 +22,7 @@ class SAA1064(object):
 
     def configure(self):
         self.master.transaction(
-            writing_bytes(displayController, 0b00000000, self.mode | self.brightness)
+            writing_bytes(displayController, 0b00000000, self.mode | self.brightness | CONTINUOUS_DISPLAY)
         )
 
     def write(self):

--- a/quick2wire/parts/saa1064.py
+++ b/quick2wire/parts/saa1064.py
@@ -9,6 +9,32 @@ STATIC_MODE = 0b00000000
 DYNAMIC_MODE = 0b00000001
 CONTINUOUS_DISPLAY = 0b00000110
 
+"""
+    Value conversions for the display segments
+
+         --64--
+        |      |
+        2      32
+        |      |
+         -- 1--
+        |      |
+        4      16
+        |      |
+         -- 8--   DP-128
+    """
+digit_map = {
+    '0':126,
+    '1':48,
+    '2':109,
+    '3':121,
+    '4':51,
+    '5':91,
+    '6':95,
+    '7':112,
+    '8':127,
+    '9':123
+}
+
 class SAA1064(object):
     def createPinBank(self, i):
         return _PinBank(i)
@@ -51,6 +77,9 @@ class SAA1064(object):
     def brightness(self, brightness):
         self._brightness = brightness
 
+    def digit(self, index):
+        return Digit(self._pin_bank[index])
+
     def pin_bank(self, index):
         return self._pin_bank[index]
 
@@ -62,6 +91,15 @@ class SAA1064(object):
     def __len__(self):
         return len(self._pin_bank)
 
+class Digit(object):
+    def __init__(self, pin_bank):
+        self._pin_bank = pin_bank
+
+    def value(self, value):
+        try:
+            self._pin_bank.value=digit_map[str(value)]
+        except:
+            raise ValueError('cannot display digit ' + value)
 
 class _PinBank(object):
     def __init__(self, index):

--- a/quick2wire/parts/saa1064.py
+++ b/quick2wire/parts/saa1064.py
@@ -17,6 +17,8 @@ class SAA1064(object):
         self.master = master
         self._mode = STATIC_MODE
         self._brightness = 0b11100000
+        if(digits > 4):
+            raise ValueError('SAA1064 only supports driving up to 4 digits')
         self._pin_bank = tuple(self.createPinBank(i) for i in range(digits))
 
     def display(self, digits):
@@ -29,30 +31,32 @@ class SAA1064(object):
 
     def write(self):
         i2c_messages = [pin_bank.i2c_message for pin_bank in self._pin_bank]
-        self.master.transaction(i2c_messages)
+        self.master.transaction(*i2c_messages)
 
     @property
     def mode(self):
         return self._mode
 
     @mode.setter
-    def mode(self, value):
-        self._mode = value
+    def mode(self, mode):
+        if(mode > 1):
+            raise ValueError('invalid mode ' + str(mode) + ' only STATIC_MODE and DYNAMIC_MODE are supported')
+        self._mode = mode
 
     @property
     def brightness(self):
         return self._brightness
 
     @brightness.setter
-    def brightness(self, value):
-        self._brightness = value
+    def brightness(self, brightness):
+        self._brightness = brightness
 
     def pin_bank(self, index):
         return self._pin_bank[index]
 
     def __getitem__(self, n):
         if 0 < n < len(self):
-            raise ValueError("no pin bank index {n} out of range", n=n)
+            raise ValueError('no pin bank index {n} out of range', n=n)
         return self._pin_bank[n]
 
     def __len__(self):
@@ -82,7 +86,7 @@ class _PinBank(object):
 
     def __getitem__(self, n):
         if 0 < n < len(self):
-            raise ValueError("no segment output index {n} out of range", n=n)
+            raise ValueError('no segment output index {n} out of range', n=n)
         return self._segment_output[n]
 
     def __len__(self):

--- a/quick2wire/parts/saa1064.py
+++ b/quick2wire/parts/saa1064.py
@@ -71,7 +71,6 @@ CONTINUOUS_DISPLAY = 0b00000110
 
 DECIMAL_POINT = 0b10000000
 
-
 digit_map = {
     '0':126,
     '1':48,
@@ -93,7 +92,7 @@ digit_map = {
 }
 
 class SAA1064(object):
-    def createPinBank(self, i):
+    def create_pin_bank(self, i):
         return _PinBank(i)
 
     def __init__(self, master, digits=1, brightness=7):
@@ -106,7 +105,7 @@ class SAA1064(object):
         else:
             self._mode = DYNAMIC_MODE
 
-        self._pin_bank = tuple(self.createPinBank(i) for i in range(digits))
+        self._pin_bank = tuple(self.create_pin_bank(i) for i in range(digits))
 
     def configure(self):
         """Writes the configured control byte to the chip."""
@@ -147,11 +146,12 @@ class SAA1064(object):
             raise ValueError('invalid brightness, valid between 0-7.')
         self._brightness = brightness << 5
 
+    #TODO: ditch this for write_digit
     def digit(self, index):
         """Returns a Digit object for the display at given 'index'."""
         return Digit(self._pin_bank[index])
 
-    def pin_bank(self, index):
+    def bank(self, index):
         """Returns a PinBank object for the display at given 'index'."""
         return self._pin_bank[index]
 
@@ -168,6 +168,7 @@ class Digit(object):
     def __init__(self, pin_bank):
         self._pin_bank = pin_bank
 
+    #convert to property
     def value(self, value):
         digit = str(value)
         try:
@@ -179,6 +180,7 @@ class Digit(object):
             raise ValueError('cannot display digit ' + value)
 
 class _PinBank(object):
+    #extends pinbankapi
     def __init__(self, index):
         self._value = 0
         self._segment_output = tuple(_OutputPin(self, i) for i in range(8))
@@ -186,6 +188,8 @@ class _PinBank(object):
 
     def segment_output(self, index):
         return self._segment_output[index]
+
+    pin = segment_output
 
     @property
     def value(self):
@@ -208,6 +212,7 @@ class _PinBank(object):
         return len(self._segment_output)
 
 class _OutputPin(object):
+    #extend pinapi
     def __init__(self, pin_bank, index):
         self._pin_bank = pin_bank
         self._binary = 2 ** index

--- a/quick2wire/parts/saa1064.py
+++ b/quick2wire/parts/saa1064.py
@@ -1,0 +1,69 @@
+from functools import reduce
+from operator import or_
+
+__author__ = 'stuartervine'
+
+from quick2wire.i2c import writing_bytes
+
+displayController = 0x38
+STATIC_MODE = 0b00000000
+DYNAMIC_MODE = 0b01000000
+
+class SAA1064(object):
+    def __init__(self, master):
+        self.master = master
+        self._mode = STATIC_MODE
+        self._brightness = 7
+        self._segment_output = tuple(_OutputPin(i) for i in range(8))
+
+    def display(self, digits):
+        pass
+
+    def configure(self):
+        self.master.transaction(
+            writing_bytes(displayController, 0b00000000, self.mode | self.brightness)
+        )
+
+    def write(self):
+        bits_to_write = [output.asBinary for output in self._segment_output]
+        byte_to_write = reduce(or_, bits_to_write)
+        self.master.transaction(
+            writing_bytes(displayController, 0b00000001, byte_to_write)
+        )
+
+    @property
+    def mode(self):
+        return self._mode
+
+    @mode.setter
+    def mode(self, value):
+        self._mode = value
+
+    @property
+    def brightness(self):
+        return self._brightness
+
+    @brightness.setter
+    def brightness(self, value):
+        self._brightness = value
+
+    def segment_output(self, index):
+        return self._segment_output[index]
+
+
+class _OutputPin(object):
+    def __init__(self, index):
+        self._value = 0
+        self._binary = 2 ** index
+
+    @property
+    def asBinary(self):
+        return self._value * self._binary
+
+    @property
+    def value(self):
+        return self._value
+
+    @value.setter
+    def value(self, value):
+        self._value = value

--- a/quick2wire/parts/saa1064.py
+++ b/quick2wire/parts/saa1064.py
@@ -1,8 +1,7 @@
-from functools import reduce
-from operator import or_
-
 __author__ = 'stuartervine'
 
+from functools import reduce
+from operator import or_
 from quick2wire.i2c import writing_bytes
 
 displayController = 0x38
@@ -11,11 +10,14 @@ DYNAMIC_MODE = 0b00000001
 CONTINUOUS_DISPLAY = 0b00000110
 
 class SAA1064(object):
-    def __init__(self, master):
+    def createPinBank(self, i):
+        return _PinBank(i)
+
+    def __init__(self, master, digits=1):
         self.master = master
         self._mode = STATIC_MODE
         self._brightness = 0b11100000
-        self._segment_output = tuple(_OutputPin(i) for i in range(8))
+        self._pin_bank = tuple(self.createPinBank(i) for i in range(digits))
 
     def display(self, digits):
         pass
@@ -26,11 +28,8 @@ class SAA1064(object):
         )
 
     def write(self):
-        bits_to_write = [output.asBinary for output in self._segment_output]
-        byte_to_write = reduce(or_, bits_to_write)
-        self.master.transaction(
-            writing_bytes(displayController, 0b00000001, byte_to_write)
-        )
+        i2c_messages = [pin_bank.i2c_message for pin_bank in self._pin_bank]
+        self.master.transaction(i2c_messages)
 
     @property
     def mode(self):
@@ -48,9 +47,39 @@ class SAA1064(object):
     def brightness(self, value):
         self._brightness = value
 
+    def pin_bank(self, index):
+        return self._pin_bank[index]
+
+    def __getitem__(self, n):
+        if 0 < n < len(self):
+            raise ValueError("no pin bank index {n} out of range", n=n)
+        return self._pin_bank[n]
+
+    def __len__(self):
+        return len(self._pin_bank)
+
+
+class _PinBank(object):
+    def __init__(self, index):
+        self._segment_output = tuple(_OutputPin(i) for i in range(8))
+        self.segment_address = index+1
+
     def segment_output(self, index):
         return self._segment_output[index]
 
+    @property
+    def i2c_message(self):
+        bits_to_write = [output.bit_value for output in self._segment_output]
+        byte_to_write = reduce(or_, bits_to_write)
+        return writing_bytes(displayController, self.segment_address, byte_to_write)
+
+    def __getitem__(self, n):
+        if 0 < n < len(self):
+            raise ValueError("no segment output index {n} out of range", n=n)
+        return self._segment_output[n]
+
+    def __len__(self):
+        return len(self._segment_output)
 
 class _OutputPin(object):
     def __init__(self, index):
@@ -58,7 +87,7 @@ class _OutputPin(object):
         self._binary = 2 ** index
 
     @property
-    def asBinary(self):
+    def bit_value(self):
         return self._value * self._binary
 
     @property

--- a/quick2wire/parts/seven_segment_display.py
+++ b/quick2wire/parts/seven_segment_display.py
@@ -10,6 +10,7 @@ class SevenSegmentDisplay(object):
         digit_values = re.findall(".\.?", value)
         digit_index=0
         for digit_value in digit_values:
-            self._driver_chip.digit(digit_index).value = digit_value
+            self._driver_chip.digit(digit_index).value(digit_value)
             digit_index += 1
+        self._driver_chip.write()
 

--- a/quick2wire/parts/seven_segment_display.py
+++ b/quick2wire/parts/seven_segment_display.py
@@ -1,0 +1,15 @@
+import re
+
+__author__ = 'stuartervine'
+
+class SevenSegmentDisplay(object):
+    def __init__(self, driver_chip):
+        self._driver_chip = driver_chip
+
+    def display(self, value):
+        digit_values = re.findall(".\.?", value)
+        digit_index=0
+        for digit_value in digit_values:
+            self._driver_chip.digit(digit_index).value = digit_value
+            digit_index += 1
+

--- a/quick2wire/parts/seven_segment_display.py
+++ b/quick2wire/parts/seven_segment_display.py
@@ -7,12 +7,11 @@ class SevenSegmentDisplay(object):
         self._driver_chip = driver_chip
 
     def display(self, value):
-        digit_values = re.findall(".\.?", str(value))
-        digit_index=0
+        self._driver_chip.reset()
 
-        #TODO: Replace with zip with index.
-        for digit_value in digit_values:
-            self._driver_chip.digit(digit_index).value=digit_value
-            digit_index += 1
+        digit_values = re.findall(".\.?", str(value))
+        for i, digit_value in zip(reversed(range(len(self._driver_chip))), reversed(digit_values)):
+            self._driver_chip.digit(i).value=digit_value
+
         self._driver_chip.write()
 

--- a/quick2wire/parts/seven_segment_display.py
+++ b/quick2wire/parts/seven_segment_display.py
@@ -7,8 +7,10 @@ class SevenSegmentDisplay(object):
         self._driver_chip = driver_chip
 
     def display(self, value):
-        digit_values = re.findall(".\.?", value)
+        digit_values = re.findall(".\.?", str(value))
         digit_index=0
+
+        #TODO: Replace with zip with index.
         for digit_value in digit_values:
             self._driver_chip.digit(digit_index).value(digit_value)
             digit_index += 1

--- a/quick2wire/parts/seven_segment_display.py
+++ b/quick2wire/parts/seven_segment_display.py
@@ -12,7 +12,7 @@ class SevenSegmentDisplay(object):
 
         #TODO: Replace with zip with index.
         for digit_value in digit_values:
-            self._driver_chip.digit(digit_index).value(digit_value)
+            self._driver_chip.digit(digit_index).value=digit_value
             digit_index += 1
         self._driver_chip.write()
 

--- a/quick2wire/parts/test_saa1064.py
+++ b/quick2wire/parts/test_saa1064.py
@@ -42,7 +42,7 @@ i2c = FakeI2CMaster()
 def setup_function(f):
     i2c.clear()
 
-def test_static_display_brightest_by_default():
+def test_static_non_blanked_brightest_display_by_default():
     saa1064 = SAA1064(i2c)
     saa1064.configure()
 
@@ -54,7 +54,7 @@ def test_static_display_brightest_by_default():
     assert controlMessage.buf[1][0] == 0b11100110
 
 
-def test_dynamic_display_brightest_by_default():
+def test_configuring_dynamic_display():
     saa1064 = SAA1064(i2c)
     saa1064.mode=DYNAMIC_MODE
     saa1064.configure()
@@ -66,7 +66,7 @@ def test_dynamic_display_brightest_by_default():
     assert controlMessage.buf[0][0] == 0b00000000
     assert controlMessage.buf[1][0] == 0b11100111
 
-def test_display_brightness():
+def test_configuring_display_brightness():
     saa1064 = SAA1064(i2c)
     saa1064.mode=DYNAMIC_MODE
     saa1064.brightness=0b01100000
@@ -79,25 +79,21 @@ def test_display_brightness():
     assert controlMessage.buf[0][0] == 0b00000000
     assert controlMessage.buf[1][0] == 0b01100111
 
-def test_setting_pins_and_writing_outputs_to_i2c():
+def test_writing_first_bank_segment_outputs_to_i2c():
     saa1064 = SAA1064(i2c)
-    saa1064.mode=STATIC_MODE
-    saa1064.brightness=5
-    saa1064.configure()
 
-    saa1064.segment_output(0).value=1
-    saa1064.segment_output(1).value=0
-    saa1064.segment_output(2).value=0
-    saa1064.segment_output(3).value=1
-    saa1064.segment_output(4).value=1
-    saa1064.segment_output(5).value=1
-    saa1064.segment_output(6).value=0
-    saa1064.segment_output(7).value=1
-
+    saa1064.pin_bank(0).segment_output(0).value=1
+    saa1064.pin_bank(0).segment_output(1).value=0
+    saa1064.pin_bank(0).segment_output(2).value=0
+    saa1064.pin_bank(0).segment_output(3).value=1
+    saa1064.pin_bank(0).segment_output(4).value=1
+    saa1064.pin_bank(0).segment_output(5).value=1
+    saa1064.pin_bank(0).segment_output(6).value=0
+    saa1064.pin_bank(0).segment_output(7).value=1
     saa1064.write()
 
-    assert i2c.request_count == 2
-    dataMessage = i2c.request(1)[0]
-    assert dataMessage.len == 2
-    assert dataMessage.buf[0][0] == 0b00000001
-    assert dataMessage.buf[1][0] == 0b10111001
+    assert i2c.request_count == 1
+    dataMessage = i2c.request(0)[0]
+    # assert dataMessage.len == 2
+    assert dataMessage[0].buf[0][0] == 0b00000001
+    assert dataMessage[0].buf[1][0] == 0b10111001

--- a/quick2wire/parts/test_saa1064.py
+++ b/quick2wire/parts/test_saa1064.py
@@ -67,14 +67,14 @@ def test_cannot_be_configured_with_invalid_brightness():
 def test_writing_single_digit_segment_outputs_to_i2c():
     saa1064 = SAA1064(i2c, digits=1)
 
-    saa1064.pin_bank(0).segment_output(0).value=1
-    saa1064.pin_bank(0).segment_output(1).value=0
-    saa1064.pin_bank(0).segment_output(2).value=0
-    saa1064.pin_bank(0).segment_output(3).value=1
-    saa1064.pin_bank(0).segment_output(4).value=1
-    saa1064.pin_bank(0).segment_output(5).value=1
-    saa1064.pin_bank(0).segment_output(6).value=0
-    saa1064.pin_bank(0).segment_output(7).value=1
+    saa1064.bank(0).segment_output(0).value=1
+    saa1064.bank(0).segment_output(1).value=0
+    saa1064.bank(0).segment_output(2).value=0
+    saa1064.bank(0).segment_output(3).value=1
+    saa1064.bank(0).segment_output(4).value=1
+    saa1064.bank(0).segment_output(5).value=1
+    saa1064.bank(0).segment_output(6).value=0
+    saa1064.bank(0).segment_output(7).value=1
     saa1064.write()
 
     assert i2c.request_count == 1
@@ -86,23 +86,23 @@ def test_writing_single_digit_segment_outputs_to_i2c():
 def test_writing_two_digit_segment_outputs_to_i2c():
     saa1064 = SAA1064(i2c, digits=2)
 
-    saa1064.pin_bank(0).segment_output(0).value=1
-    saa1064.pin_bank(0).segment_output(1).value=0
-    saa1064.pin_bank(0).segment_output(2).value=1
-    saa1064.pin_bank(0).segment_output(3).value=0
-    saa1064.pin_bank(0).segment_output(4).value=0
-    saa1064.pin_bank(0).segment_output(5).value=0
-    saa1064.pin_bank(0).segment_output(6).value=0
-    saa1064.pin_bank(0).segment_output(7).value=0
+    saa1064.bank(0).segment_output(0).value=1
+    saa1064.bank(0).segment_output(1).value=0
+    saa1064.bank(0).segment_output(2).value=1
+    saa1064.bank(0).segment_output(3).value=0
+    saa1064.bank(0).segment_output(4).value=0
+    saa1064.bank(0).segment_output(5).value=0
+    saa1064.bank(0).segment_output(6).value=0
+    saa1064.bank(0).segment_output(7).value=0
 
-    saa1064.pin_bank(1).segment_output(0).value=0
-    saa1064.pin_bank(1).segment_output(1).value=0
-    saa1064.pin_bank(1).segment_output(2).value=0
-    saa1064.pin_bank(1).segment_output(3).value=0
-    saa1064.pin_bank(1).segment_output(4).value=1
-    saa1064.pin_bank(1).segment_output(5).value=0
-    saa1064.pin_bank(1).segment_output(6).value=1
-    saa1064.pin_bank(1).segment_output(7).value=0
+    saa1064.bank(1).segment_output(0).value=0
+    saa1064.bank(1).segment_output(1).value=0
+    saa1064.bank(1).segment_output(2).value=0
+    saa1064.bank(1).segment_output(3).value=0
+    saa1064.bank(1).segment_output(4).value=1
+    saa1064.bank(1).segment_output(5).value=0
+    saa1064.bank(1).segment_output(6).value=1
+    saa1064.bank(1).segment_output(7).value=0
     saa1064.write()
 
     assert i2c.request_count == 1
@@ -120,10 +120,10 @@ def test_writing_two_digit_segment_outputs_to_i2c():
 def test_writing_four_digit_segment_outputs_to_i2c():
     saa1064 = SAA1064(i2c, digits=4)
 
-    saa1064.pin_bank(0).value=255
-    saa1064.pin_bank(1).value=127
-    saa1064.pin_bank(2).value=63
-    saa1064.pin_bank(3).value=31
+    saa1064.bank(0).value=255
+    saa1064.bank(1).value=127
+    saa1064.bank(2).value=63
+    saa1064.bank(3).value=31
     saa1064.write()
 
     assert i2c.request_count == 1

--- a/quick2wire/parts/test_saa1064.py
+++ b/quick2wire/parts/test_saa1064.py
@@ -83,6 +83,19 @@ def test_writing_single_digit_segment_outputs_to_i2c():
     assert dataMessage.byte(0) == 0b00000001
     assert dataMessage.byte(1) == 0b10111001
 
+def test_individual_pin_values_can_be_read():
+    saa1064 = SAA1064(i2c, digits=1)
+
+    saa1064.bank(0).segment_output(0).value=1
+    saa1064.bank(0).segment_output(1).value=0
+    saa1064.bank(0).segment_output(2).value=0
+    saa1064.bank(0).segment_output(3).value=1
+
+    assert saa1064.bank(0).segment_output(0).value == 1
+    assert saa1064.bank(0).segment_output(1).value == 0
+    assert saa1064.bank(0).segment_output(2).value == 0
+    assert saa1064.bank(0).segment_output(3).value == 1
+
 def test_writing_two_digit_segment_outputs_to_i2c():
     saa1064 = SAA1064(i2c, digits=2)
 
@@ -151,8 +164,8 @@ def test_writing_four_digit_segment_outputs_to_i2c():
 def test_digits_are_mapped_into_correct_i2c_message():
     saa1064 = SAA1064(i2c, digits=2)
 
-    saa1064.digit(0).value('9')
-    saa1064.digit(1).value('5')
+    saa1064.digit(0).value='9'
+    saa1064.digit(1).value='5'
     saa1064.write()
 
     assert i2c.request_count == 1
@@ -169,7 +182,7 @@ def test_digits_are_mapped_into_correct_i2c_message():
 def test_digits_can_be_set_using_integer_value():
     saa1064 = SAA1064(i2c, digits=2)
 
-    saa1064.digit(0).value(9)
+    saa1064.digit(0).value=9
     saa1064.write()
 
     assert i2c.request_count == 1
@@ -181,7 +194,7 @@ def test_digits_can_be_set_using_integer_value():
 def test_digit_with_decimal_point_sets_bit_for_decimal_point():
     saa1064 = SAA1064(i2c, digits=2)
 
-    saa1064.digit(0).value('9.')
+    saa1064.digit(0).value='9.'
     saa1064.write()
 
     assert i2c.request_count == 1
@@ -194,4 +207,4 @@ def test_does_not_accept_invalid_digit_values():
     saa1064 = SAA1064(i2c, digits=2)
 
     with pytest.raises(ValueError):
-        saa1064.digit(0).value('@')
+        saa1064.digit(0).value='@'

--- a/quick2wire/parts/test_saa1064.py
+++ b/quick2wire/parts/test_saa1064.py
@@ -1,0 +1,103 @@
+from quick2wire.i2c_ctypes import I2C_M_RD
+from quick2wire.parts.saa1064 import SAA1064, STATIC_MODE, DYNAMIC_MODE
+
+__author__ = 'stuartervine'
+
+
+class FakeI2CMaster:
+    def __init__(self):
+        self._requests = []
+        self._responses = []
+        self._next_response = 0
+        self.message_precondition = lambda m: True
+
+    def all_messages_must(self, p):
+        self.message_precondition
+
+    def clear(self):
+        self.__init__()
+
+    def transaction(self, *messages):
+        for m in messages:
+            self.message_precondition(m)
+
+        self._requests.append(messages)
+        return []
+
+    def add_response(self, *messages):
+        self._responses.append(messages)
+
+
+    @property
+    def request_count(self):
+        return len(self._requests)
+
+
+    def request(self, n):
+        return self._requests[n]
+
+
+i2c = FakeI2CMaster()
+
+def setup_function(f):
+    i2c.clear()
+
+def test_static_display_brightest_by_default():
+    saa1064 = SAA1064(i2c)
+    saa1064.configure()
+
+    assert i2c.request_count == 1
+
+    controlMessage = i2c.request(0)[0]
+    assert controlMessage.len == 2
+    assert controlMessage.buf[0][0] == 0b00000000
+    assert controlMessage.buf[1][0] == 0b00000111
+
+
+def test_dynamic_display_brightest_by_default():
+    saa1064 = SAA1064(i2c)
+    saa1064.mode=DYNAMIC_MODE
+    saa1064.configure()
+
+    assert i2c.request_count == 1
+
+    controlMessage = i2c.request(0)[0]
+    assert controlMessage.len == 2
+    assert controlMessage.buf[0][0] == 0b00000000
+    assert controlMessage.buf[1][0] == 0b01000111
+
+def test_display_brightness():
+    saa1064 = SAA1064(i2c)
+    saa1064.mode=DYNAMIC_MODE
+    saa1064.brightness=5
+    saa1064.configure()
+
+    assert i2c.request_count == 1
+
+    controlMessage = i2c.request(0)[0]
+    assert controlMessage.len == 2
+    assert controlMessage.buf[0][0] == 0b00000000
+    assert controlMessage.buf[1][0] == 0b01000101
+
+def test_setting_pins_and_writing_outputs_to_i2c():
+    saa1064 = SAA1064(i2c)
+    saa1064.mode=STATIC_MODE
+    saa1064.brightness=5
+    saa1064.configure()
+
+    saa1064.segment_output(0).value=1
+    saa1064.segment_output(1).value=0
+    saa1064.segment_output(2).value=0
+    saa1064.segment_output(3).value=1
+    saa1064.segment_output(4).value=1
+    saa1064.segment_output(5).value=1
+    saa1064.segment_output(6).value=0
+    saa1064.segment_output(7).value=1
+
+    saa1064.write()
+
+    assert i2c.request_count == 2
+    dataMessage = i2c.request(1)[0]
+    assert dataMessage.len == 2
+    assert dataMessage.buf[0][0] == 0b00000001
+    assert dataMessage.buf[1][0] == 0b10111001

--- a/quick2wire/parts/test_saa1064.py
+++ b/quick2wire/parts/test_saa1064.py
@@ -140,4 +140,38 @@ def test_writing_four_digit_segment_outputs_to_i2c():
     assert message4.byte(0) == 4
     assert message4.byte(1) == 31
 
+def test_digits_are_mapped_into_correct_i2c_message():
+    saa1064 = SAA1064(i2c, digits=2)
 
+    saa1064.digit(0).value('9')
+    saa1064.digit(1).value('5')
+    saa1064.write()
+
+    assert i2c.request_count == 1
+    message1 = i2c.message(0)
+    assert message1.len == 2
+    assert message1.byte(0) == 1
+    assert message1.byte(1) == 123
+
+    message2 = i2c.message(1)
+    assert message2.len == 2
+    assert message2.byte(0) == 2
+    assert message2.byte(1) == 91
+
+def test_digits_can_be_set_using_integer_value():
+    saa1064 = SAA1064(i2c, digits=2)
+
+    saa1064.digit(0).value(9)
+    saa1064.write()
+
+    assert i2c.request_count == 1
+    message1 = i2c.message(0)
+    assert message1.len == 2
+    assert message1.byte(0) == 1
+    assert message1.byte(1) == 123
+
+def test_does_not_accept_invalid_digit_values():
+    saa1064 = SAA1064(i2c, digits=2)
+
+    with pytest.raises(ValueError):
+        saa1064.digit(0).value('@')

--- a/quick2wire/parts/test_saa1064.py
+++ b/quick2wire/parts/test_saa1064.py
@@ -178,6 +178,18 @@ def test_digits_can_be_set_using_integer_value():
     assert message1.byte(0) == 1
     assert message1.byte(1) == 123
 
+def test_digit_with_decimal_point_sets_bit_for_decimal_point():
+    saa1064 = SAA1064(i2c, digits=2)
+
+    saa1064.digit(0).value('9.')
+    saa1064.write()
+
+    assert i2c.request_count == 1
+    message1 = i2c.message(0)
+    assert message1.len == 2
+    assert message1.byte(0) == 1
+    assert message1.byte(1) == 251
+
 def test_does_not_accept_invalid_digit_values():
     saa1064 = SAA1064(i2c, digits=2)
 

--- a/quick2wire/parts/test_saa1064.py
+++ b/quick2wire/parts/test_saa1064.py
@@ -36,6 +36,17 @@ class FakeI2CMaster:
     def request(self, n):
         return self._requests[n]
 
+    def message(self, request_index, message_index):
+        request = self.request(0)
+        return I2CMessageWrapper(request[request_index][message_index])
+
+class I2CMessageWrapper:
+    def __init__(self, i2_message):
+        self._i2c_message = i2_message
+        self.len = i2_message.len
+
+    def byte(self, index):
+        return self._i2c_message.buf[index][0]
 
 i2c = FakeI2CMaster()
 
@@ -79,8 +90,8 @@ def test_configuring_display_brightness():
     assert controlMessage.buf[0][0] == 0b00000000
     assert controlMessage.buf[1][0] == 0b01100111
 
-def test_writing_first_bank_segment_outputs_to_i2c():
-    saa1064 = SAA1064(i2c)
+def test_writing_single_digit_segment_outputs_to_i2c():
+    saa1064 = SAA1064(i2c, digits=1)
 
     saa1064.pin_bank(0).segment_output(0).value=1
     saa1064.pin_bank(0).segment_output(1).value=0
@@ -93,7 +104,41 @@ def test_writing_first_bank_segment_outputs_to_i2c():
     saa1064.write()
 
     assert i2c.request_count == 1
-    dataMessage = i2c.request(0)[0]
-    # assert dataMessage.len == 2
-    assert dataMessage[0].buf[0][0] == 0b00000001
-    assert dataMessage[0].buf[1][0] == 0b10111001
+    dataMessage = i2c.message(0, 0)
+    assert dataMessage.len == 2
+    assert dataMessage.byte(0) == 0b00000001
+    assert dataMessage.byte(1) == 0b10111001
+
+def test_writing_two_digit_segment_outputs_to_i2c():
+    saa1064 = SAA1064(i2c, digits=2)
+
+    saa1064.pin_bank(0).segment_output(0).value=1
+    saa1064.pin_bank(0).segment_output(1).value=0
+    saa1064.pin_bank(0).segment_output(2).value=1
+    saa1064.pin_bank(0).segment_output(3).value=0
+    saa1064.pin_bank(0).segment_output(4).value=0
+    saa1064.pin_bank(0).segment_output(5).value=0
+    saa1064.pin_bank(0).segment_output(6).value=0
+    saa1064.pin_bank(0).segment_output(7).value=0
+
+    saa1064.pin_bank(1).segment_output(0).value=0
+    saa1064.pin_bank(1).segment_output(1).value=0
+    saa1064.pin_bank(1).segment_output(2).value=0
+    saa1064.pin_bank(1).segment_output(3).value=0
+    saa1064.pin_bank(1).segment_output(4).value=1
+    saa1064.pin_bank(1).segment_output(5).value=0
+    saa1064.pin_bank(1).segment_output(6).value=1
+    saa1064.pin_bank(1).segment_output(7).value=0
+    saa1064.write()
+
+    assert i2c.request_count == 1
+
+    message1 = i2c.message(0, 0)
+    assert message1.len == 2
+    assert message1.byte(0) == 0b00000001
+    assert message1.byte(1) == 0b00000101
+
+    message2 = i2c.message(0, 1)
+    assert message2.len == 2
+    assert message2.byte(0) == 0b00000010
+    assert message2.byte(1) == 0b01010000

--- a/quick2wire/parts/test_saa1064.py
+++ b/quick2wire/parts/test_saa1064.py
@@ -51,7 +51,7 @@ def test_static_display_brightest_by_default():
     controlMessage = i2c.request(0)[0]
     assert controlMessage.len == 2
     assert controlMessage.buf[0][0] == 0b00000000
-    assert controlMessage.buf[1][0] == 0b00000111
+    assert controlMessage.buf[1][0] == 0b11100110
 
 
 def test_dynamic_display_brightest_by_default():
@@ -64,12 +64,12 @@ def test_dynamic_display_brightest_by_default():
     controlMessage = i2c.request(0)[0]
     assert controlMessage.len == 2
     assert controlMessage.buf[0][0] == 0b00000000
-    assert controlMessage.buf[1][0] == 0b01000111
+    assert controlMessage.buf[1][0] == 0b11100111
 
 def test_display_brightness():
     saa1064 = SAA1064(i2c)
     saa1064.mode=DYNAMIC_MODE
-    saa1064.brightness=5
+    saa1064.brightness=0b01100000
     saa1064.configure()
 
     assert i2c.request_count == 1
@@ -77,7 +77,7 @@ def test_display_brightness():
     controlMessage = i2c.request(0)[0]
     assert controlMessage.len == 2
     assert controlMessage.buf[0][0] == 0b00000000
-    assert controlMessage.buf[1][0] == 0b01000101
+    assert controlMessage.buf[1][0] == 0b01100111
 
 def test_setting_pins_and_writing_outputs_to_i2c():
     saa1064 = SAA1064(i2c)

--- a/quick2wire/parts/test_saa1064.py
+++ b/quick2wire/parts/test_saa1064.py
@@ -41,7 +41,7 @@ def test_configuring_dynamic_display():
 def test_configuring_display_brightness():
     saa1064 = SAA1064(i2c)
     saa1064.mode=DYNAMIC_MODE
-    saa1064.brightness=0b01100000
+    saa1064.brightness=3
     saa1064.configure()
 
     assert i2c.request_count == 1
@@ -55,6 +55,14 @@ def test_cannot_be_configured_with_invalid_mode():
     saa1064 = SAA1064(i2c)
     with pytest.raises(ValueError):
         saa1064.mode=99
+
+def test_cannot_be_configured_with_invalid_brightness():
+    saa1064 = SAA1064(i2c)
+    for x in range(8):
+        saa1064.brightness = x
+
+    with pytest.raises(ValueError):
+        saa1064.brightness=8
 
 def test_writing_single_digit_segment_outputs_to_i2c():
     saa1064 = SAA1064(i2c, digits=1)

--- a/quick2wire/parts/test_saa1064.py
+++ b/quick2wire/parts/test_saa1064.py
@@ -1,69 +1,30 @@
+import pytest
 from quick2wire.i2c_ctypes import I2C_M_RD
+from quick2wire.parts.fake_i2c import FakeI2CMaster
 from quick2wire.parts.saa1064 import SAA1064, STATIC_MODE, DYNAMIC_MODE
 
 __author__ = 'stuartervine'
-
-
-class FakeI2CMaster:
-    def __init__(self):
-        self._requests = []
-        self._responses = []
-        self._next_response = 0
-        self.message_precondition = lambda m: True
-
-    def all_messages_must(self, p):
-        self.message_precondition
-
-    def clear(self):
-        self.__init__()
-
-    def transaction(self, *messages):
-        for m in messages:
-            self.message_precondition(m)
-
-        self._requests.append(messages)
-        return []
-
-    def add_response(self, *messages):
-        self._responses.append(messages)
-
-
-    @property
-    def request_count(self):
-        return len(self._requests)
-
-
-    def request(self, n):
-        return self._requests[n]
-
-    def message(self, request_index, message_index):
-        request = self.request(0)
-        return I2CMessageWrapper(request[request_index][message_index])
-
-class I2CMessageWrapper:
-    def __init__(self, i2_message):
-        self._i2c_message = i2_message
-        self.len = i2_message.len
-
-    def byte(self, index):
-        return self._i2c_message.buf[index][0]
 
 i2c = FakeI2CMaster()
 
 def setup_function(f):
     i2c.clear()
 
-def test_static_non_blanked_brightest_display_by_default():
-    saa1064 = SAA1064(i2c)
-    saa1064.configure()
+def test_cannot_be_created_with_invalid_number_of_digits():
+    with pytest.raises(ValueError):
+        SAA1064(i2c, digits=5)
 
+def test_static_non_blanked_brightest_display_single_digit_by_default():
+    saa1064 = SAA1064(i2c)
+    assert len(saa1064._pin_bank) == 1
+
+    saa1064.configure()
     assert i2c.request_count == 1
 
     controlMessage = i2c.request(0)[0]
     assert controlMessage.len == 2
     assert controlMessage.buf[0][0] == 0b00000000
     assert controlMessage.buf[1][0] == 0b11100110
-
 
 def test_configuring_dynamic_display():
     saa1064 = SAA1064(i2c)
@@ -90,6 +51,11 @@ def test_configuring_display_brightness():
     assert controlMessage.buf[0][0] == 0b00000000
     assert controlMessage.buf[1][0] == 0b01100111
 
+def test_cannot_be_configured_with_invalid_mode():
+    saa1064 = SAA1064(i2c)
+    with pytest.raises(ValueError):
+        saa1064.mode=99
+
 def test_writing_single_digit_segment_outputs_to_i2c():
     saa1064 = SAA1064(i2c, digits=1)
 
@@ -104,7 +70,7 @@ def test_writing_single_digit_segment_outputs_to_i2c():
     saa1064.write()
 
     assert i2c.request_count == 1
-    dataMessage = i2c.message(0, 0)
+    dataMessage = i2c.message(0)
     assert dataMessage.len == 2
     assert dataMessage.byte(0) == 0b00000001
     assert dataMessage.byte(1) == 0b10111001
@@ -133,12 +99,12 @@ def test_writing_two_digit_segment_outputs_to_i2c():
 
     assert i2c.request_count == 1
 
-    message1 = i2c.message(0, 0)
+    message1 = i2c.message(0)
     assert message1.len == 2
     assert message1.byte(0) == 0b00000001
     assert message1.byte(1) == 0b00000101
 
-    message2 = i2c.message(0, 1)
+    message2 = i2c.message(1)
     assert message2.len == 2
     assert message2.byte(0) == 0b00000010
     assert message2.byte(1) == 0b01010000
@@ -154,22 +120,22 @@ def test_writing_four_digit_segment_outputs_to_i2c():
 
     assert i2c.request_count == 1
 
-    message1 = i2c.message(0, 0)
+    message1 = i2c.message(0)
     assert message1.len == 2
     assert message1.byte(0) == 1
     assert message1.byte(1) == 255
 
-    message2 = i2c.message(0, 1)
+    message2 = i2c.message(1)
     assert message2.len == 2
     assert message2.byte(0) == 2
     assert message2.byte(1) == 127
 
-    message3 = i2c.message(0, 2)
+    message3 = i2c.message(2)
     assert message3.len == 2
     assert message3.byte(0) == 3
     assert message3.byte(1) == 63
 
-    message4 = i2c.message(0, 3)
+    message4 = i2c.message(3)
     assert message4.len == 2
     assert message4.byte(0) == 4
     assert message4.byte(1) == 31

--- a/quick2wire/parts/test_saa1064.py
+++ b/quick2wire/parts/test_saa1064.py
@@ -142,3 +142,36 @@ def test_writing_two_digit_segment_outputs_to_i2c():
     assert message2.len == 2
     assert message2.byte(0) == 0b00000010
     assert message2.byte(1) == 0b01010000
+
+def test_writing_four_digit_segment_outputs_to_i2c():
+    saa1064 = SAA1064(i2c, digits=4)
+
+    saa1064.pin_bank(0).value=255
+    saa1064.pin_bank(1).value=127
+    saa1064.pin_bank(2).value=63
+    saa1064.pin_bank(3).value=31
+    saa1064.write()
+
+    assert i2c.request_count == 1
+
+    message1 = i2c.message(0, 0)
+    assert message1.len == 2
+    assert message1.byte(0) == 1
+    assert message1.byte(1) == 255
+
+    message2 = i2c.message(0, 1)
+    assert message2.len == 2
+    assert message2.byte(0) == 2
+    assert message2.byte(1) == 127
+
+    message3 = i2c.message(0, 2)
+    assert message3.len == 2
+    assert message3.byte(0) == 3
+    assert message3.byte(1) == 63
+
+    message4 = i2c.message(0, 3)
+    assert message4.len == 2
+    assert message4.byte(0) == 4
+    assert message4.byte(1) == 31
+
+

--- a/quick2wire/parts/test_seven_segment_display.py
+++ b/quick2wire/parts/test_seven_segment_display.py
@@ -5,10 +5,10 @@ __author__ = 'stuartervine'
 
 class FakeDigit(object):
     def __init__(self):
-        self.value = 0
+        self._value = 0
 
     def value(self, value):
-        self.value = value
+        self._value = value
 
 class FakeSAA1064(object):
     def __init__(self):
@@ -17,25 +17,31 @@ class FakeSAA1064(object):
     def digit(self, index):
         return self._fake_digits[index]
 
+    def write(self):
+        pass
+
+    def __len__(self):
+        return len(self._fake_digits)
+
 saa1064 = FakeSAA1064()
 
 def test_cannot_be_created_with_invalid_number_of_digits():
     display = SevenSegmentDisplay(saa1064)
     display.display('1234')
-    assert saa1064.digit(0).value == '1'
-    assert saa1064.digit(1).value == '2'
-    assert saa1064.digit(2).value == '3'
-    assert saa1064.digit(3).value == '4'
+    assert saa1064.digit(0)._value == '1'
+    assert saa1064.digit(1)._value == '2'
+    assert saa1064.digit(2)._value == '3'
+    assert saa1064.digit(3)._value == '4'
 
 def test_shows_decimal_point():
     display = SevenSegmentDisplay(saa1064)
     display.display('0.123')
-    assert saa1064.digit(0).value == '0.'
-    assert saa1064.digit(1).value == '1'
-    assert saa1064.digit(2).value == '2'
-    assert saa1064.digit(3).value == '3'
+    assert saa1064.digit(0)._value == '0.'
+    assert saa1064.digit(1)._value == '1'
+    assert saa1064.digit(2)._value == '2'
+    assert saa1064.digit(3)._value == '3'
 
 def test_hands_through_potentially_undisplayable_values():
     display = SevenSegmentDisplay(saa1064)
     display.display('@')
-    assert saa1064.digit(0).value == '@'
+    assert saa1064.digit(0)._value == '@'

--- a/quick2wire/parts/test_seven_segment_display.py
+++ b/quick2wire/parts/test_seven_segment_display.py
@@ -11,6 +11,10 @@ class FakeSAA1064(object):
     def __init__(self):
         self._fake_digits = [FakeDigit() for x in range(4)]
 
+    def reset(self):
+        for digit in self._fake_digits:
+            digit.value = 0
+
     def digit(self, index):
         return self._fake_digits[index]
 
@@ -41,4 +45,13 @@ def test_shows_decimal_point():
 def test_hands_through_potentially_undisplayable_values():
     display = SevenSegmentDisplay(saa1064)
     display.display('@')
-    assert saa1064.digit(0).value == '@'
+    assert saa1064.digit(3).value == '@'
+
+def test_pads_unused_digits_when_not_all_are_used():
+    display = SevenSegmentDisplay(saa1064)
+    display.display('12')
+    assert saa1064.digit(0).value == 0
+    assert saa1064.digit(1).value == 0
+    assert saa1064.digit(2).value == '1'
+    assert saa1064.digit(3).value == '2'
+

--- a/quick2wire/parts/test_seven_segment_display.py
+++ b/quick2wire/parts/test_seven_segment_display.py
@@ -5,10 +5,7 @@ __author__ = 'stuartervine'
 
 class FakeDigit(object):
     def __init__(self):
-        self._value = 0
-
-    def value(self, value):
-        self._value = value
+        self.value = 0
 
 class FakeSAA1064(object):
     def __init__(self):
@@ -28,20 +25,20 @@ saa1064 = FakeSAA1064()
 def test_cannot_be_created_with_invalid_number_of_digits():
     display = SevenSegmentDisplay(saa1064)
     display.display('1234')
-    assert saa1064.digit(0)._value == '1'
-    assert saa1064.digit(1)._value == '2'
-    assert saa1064.digit(2)._value == '3'
-    assert saa1064.digit(3)._value == '4'
+    assert saa1064.digit(0).value == '1'
+    assert saa1064.digit(1).value == '2'
+    assert saa1064.digit(2).value == '3'
+    assert saa1064.digit(3).value == '4'
 
 def test_shows_decimal_point():
     display = SevenSegmentDisplay(saa1064)
     display.display('0.123')
-    assert saa1064.digit(0)._value == '0.'
-    assert saa1064.digit(1)._value == '1'
-    assert saa1064.digit(2)._value == '2'
-    assert saa1064.digit(3)._value == '3'
+    assert saa1064.digit(0).value == '0.'
+    assert saa1064.digit(1).value == '1'
+    assert saa1064.digit(2).value == '2'
+    assert saa1064.digit(3).value == '3'
 
 def test_hands_through_potentially_undisplayable_values():
     display = SevenSegmentDisplay(saa1064)
     display.display('@')
-    assert saa1064.digit(0)._value == '@'
+    assert saa1064.digit(0).value == '@'

--- a/quick2wire/parts/test_seven_segment_display.py
+++ b/quick2wire/parts/test_seven_segment_display.py
@@ -1,0 +1,41 @@
+from quick2wire.parts.saa1064 import DECIMAL_POINT
+from quick2wire.parts.seven_segment_display import SevenSegmentDisplay
+
+__author__ = 'stuartervine'
+
+class FakeDigit(object):
+    def __init__(self):
+        self.value = 0
+
+    def value(self, value):
+        self.value = value
+
+class FakeSAA1064(object):
+    def __init__(self):
+        self._fake_digits = [FakeDigit() for x in range(4)]
+
+    def digit(self, index):
+        return self._fake_digits[index]
+
+saa1064 = FakeSAA1064()
+
+def test_cannot_be_created_with_invalid_number_of_digits():
+    display = SevenSegmentDisplay(saa1064)
+    display.display('1234')
+    assert saa1064.digit(0).value == '1'
+    assert saa1064.digit(1).value == '2'
+    assert saa1064.digit(2).value == '3'
+    assert saa1064.digit(3).value == '4'
+
+def test_shows_decimal_point():
+    display = SevenSegmentDisplay(saa1064)
+    display.display('0.123')
+    assert saa1064.digit(0).value == '0.'
+    assert saa1064.digit(1).value == '1'
+    assert saa1064.digit(2).value == '2'
+    assert saa1064.digit(3).value == '3'
+
+def test_hands_through_potentially_undisplayable_values():
+    display = SevenSegmentDisplay(saa1064)
+    display.display('@')
+    assert saa1064.digit(0).value == '@'

--- a/quick2wire/pin.py
+++ b/quick2wire/pin.py
@@ -1,0 +1,36 @@
+class PinAPI(object):
+    def __init__(self, bank, index):
+        self._bank = bank
+        self._index = index
+
+    @property
+    def index(self):
+        return self._index
+
+    @property
+    def bank(self):
+        return self._bank
+
+    def __enter__(self):
+        self.open()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.close()
+
+    value = property(lambda p: p.get(),
+                     lambda p,v: p.set(v),
+                     doc="""The value of the pin: 1 if the pin is high, 0 if the pin is low.""")
+
+
+class PinBankAPI(object):
+    def __getitem__(self, n):
+        if 0 < n < len(self):
+            raise ValueError("no pin index {n} out of range", n=n)
+        return self.pin(n)
+
+    def write(self):
+        pass
+
+    def read(self):
+        pass


### PR DESCRIPTION
Updated to extract the Pin & PinBank APIs and reuse in the SAA1064 chip API. Also corrected the way the higher level display API works, as it wasn't padding out unused digits. So on a 4 digit display, displaying '1' would show '1---' (where - represents a blank digit), rather than '---1'.
