### PR TITLE
Update spi.py

### DIFF
--- a/quick2wire/spi.py
+++ b/quick2wire/spi.py
@@ -1,5 +1,5 @@
 import sys
-from ctypes import addressof, create_string_buffer, sizeof, string_at
+from ctypes import addressof, create_string_buffer, sizeof, string_at, c_int32, c_uint32
 import struct
 import posix
 from fcntl import ioctl
@@ -61,7 +61,7 @@ class SPIDevice:
         for i, transfer in enumerate(transfers):
             ioctl_arg[i] = transfers[i].to_spi_ioc_transfer()
 
-        ioctl(self.fd, SPI_IOC_MESSAGE(transfer_count), addressof(ioctl_arg))
+        ioctl(self.fd, SPI_IOC_MESSAGE(transfer_count), c_int32(c_uint32(addressof(ioctl_arg)).value).value)
 
         return [transfer.to_read_bytes() for t in transfers if t.has_read_buf]
 


### PR DESCRIPTION
Have you ever got any problem with this module?! I've encountered that calling transaction from other thread can generate 64 bit integer that ioctl does not accept it and i read exception! (OverflowError: Python int too large to convert to C long) Therefore i convert it to 32 bit...
