### PR TITLE
docs: Fix a few typos

### DIFF
--- a/quick2wire/parts/mcp23x17.py
+++ b/quick2wire/parts/mcp23x17.py
@@ -15,7 +15,7 @@ from quick2wire.gpio import PinAPI, PinBankAPI
 In = "in"
 Out = "out"
 
-# Bits within the IOCON regiseter
+# Bits within the IOCON register
 IOCON_INTPOL=1
 IOCON_ODR=2
 IOCON_MIRROR=6

--- a/quick2wire/selector.py
+++ b/quick2wire/selector.py
@@ -58,7 +58,7 @@ class Selector(SelfClosing):
                                         the source
                       OUTPUT         -- output can be written to the source
                       ERROR          -- an error has occurred on the source
-                      HANGUP         -- a remote hangup has occured on the 
+                      HANGUP         -- a remote hangup has occurred on the 
                                         source
                       PRIORITY_INPUT -- urgent out-of-band data is waiting 
                                         to be read from the source
@@ -130,7 +130,7 @@ class Selector(SelfClosing):
     
     @property
     def has_hangup(self):
-        """Returns whether a remote hangup has occured on the ready event source."""
+        """Returns whether a remote hangup has occurred on the ready event source."""
         return bool(self.events & HANGUP)
     
     @property

--- a/quick2wire/spi_ctypes.py
+++ b/quick2wire/spi_ctypes.py
@@ -46,7 +46,7 @@ SPI_IOC_MAGIC = 107 # ord('k')
 # are in a different address space (and may be of different sizes in some
 # cases, such as 32-bit i386 userspace over a 64-bit x86_64 kernel).
 # Zero-initialize the structure, including currently unused fields, to
-# accomodate potential future updates.
+# accommodate potential future updates.
 #
 # SPI_IOC_MESSAGE gives userspace the equivalent of kernel spi_sync().
 # Pass it an array of related transfers, they'll execute together.


### PR DESCRIPTION
There are small typos in:
- quick2wire/parts/mcp23x17.py
- quick2wire/selector.py
- quick2wire/spi_ctypes.py

Fixes:
- Should read `occurred` rather than `occured`.
- Should read `register` rather than `regiseter`.
- Should read `accommodate` rather than `accomodate`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md